### PR TITLE
Revert "chore(deps): bump typescript from 5.0.4 to 5.4.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "tailwindcss": "3.3.2",
     "tailwindcss-animate": "^1.0.6",
     "three": "^0.161.0",
-    "typescript": "5.4.5",
+    "typescript": "5.0.4",
     "uploadthing": "^4.0.0",
     "zod": "^3.21.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5538,10 +5538,10 @@ typed-array-length@^1.0.5:
     is-typed-array "^1.1.13"
     possible-typed-array-names "^1.0.0"
 
-typescript@5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 ua-parser-js@^0.7.18:
   version "0.7.37"


### PR DESCRIPTION
Reverts typescript version update Fix: @ts-expect-error server component error on build.